### PR TITLE
Save the Log file in same DIR as PHP agent.

### DIFF
--- a/hetrixtools_agent.php
+++ b/hetrixtools_agent.php
@@ -322,7 +322,7 @@ $post_data = "$os|$uptime|$cpu_model|$cpu_speed|$cpu_cores|$cpu_usage|$cpu_iowai
 $post = "v=$version&a=1&s=$SID&d=$post_data";
 
 // Log the current post string (for debugging)
-file_put_contents('hetrixtools_agent.log',$post);
+file_put_contents(dirname(__FILE__).'/hetrixtools_agent.log',$post);
 
 // Post the data to HetrixTools
 $ch = curl_init('https://sm.hetrixtools.net');


### PR DESCRIPTION
Save the Log `hetrixtools_agent.log` file in same Directory as HetrixTools Server Monitoring Agent (PHP) `hetrixtools_agent.php` file.

So that it does not store in arbitrary directory in shared web hosting server,
Where user may not have access to that Directory.

Best regards 👍 